### PR TITLE
chore: add prettier for formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+CHANGELOG.md
+pnpm-lock.yaml

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
     <meta charset="utf-8" />

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   "scripts": {
     "prepare": "pnpm run build",
     "build": "cm-buildhelper src/catppuccin.ts",
-    "watch": "nodemon --watch src -e ts --exec 'pnpm build'"
+    "watch": "nodemon --watch src -e ts --exec 'pnpm build'",
+    "format": "prettier --write ."
   },
   "files": [
     "dist"
@@ -52,7 +53,8 @@
   },
   "devDependencies": {
     "@codemirror/buildhelper": "^1.0.0",
-    "nodemon": "^3.1.14"
+    "nodemon": "^3.1.14",
+    "prettier": "3.8.1"
   },
   "packageManager": "pnpm@10.33.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       nodemon:
         specifier: ^3.1.14
         version: 3.1.14
+      prettier:
+        specifier: 3.8.1
+        version: 3.8.1
 
 packages:
 
@@ -556,6 +559,11 @@ packages:
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
+
+  prettier@3.8.1:
+    resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
+    engines: {node: '>=14'}
+    hasBin: true
 
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
@@ -1221,6 +1229,8 @@ snapshots:
     optional: true
 
   picomatch@2.3.1: {}
+
+  prettier@3.8.1: {}
 
   process-nextick-args@2.0.1: {}
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "local>catppuccin/renovate-config"
-  ]
+  "extends": ["local>catppuccin/renovate-config"]
 }

--- a/src/catppuccin.ts
+++ b/src/catppuccin.ts
@@ -92,19 +92,13 @@ function createCatppuccinTheme(flavor: CatppuccinFlavor) {
         },
       },
     },
-    { dark: isDark }
+    { dark: isDark },
   );
 
   const highlightStyle = HighlightStyle.define([
     { tag: t.keyword, color: colors.mauve.hex },
     {
-      tag: [
-        t.name,
-        t.definition(t.name),
-        t.deleted,
-        t.character,
-        t.macroName,
-      ],
+      tag: [t.name, t.definition(t.name), t.deleted, t.character, t.macroName],
       color: colors.text.hex,
     },
     {
@@ -155,9 +149,9 @@ function createCatppuccinTheme(flavor: CatppuccinFlavor) {
 // Create extensions for all variants
 export const catppuccinLatte: Extension = createCatppuccinTheme(flavors.latte);
 export const catppuccinFrappe: Extension = createCatppuccinTheme(
-  flavors.frappe
+  flavors.frappe,
 );
 export const catppuccinMacchiato: Extension = createCatppuccinTheme(
-  flavors.macchiato
+  flavors.macchiato,
 );
 export const catppuccinMocha: Extension = createCatppuccinTheme(flavors.mocha);


### PR DESCRIPTION
As pull requests are adding new things (#28) it might help to have some standard formatting. The existing formatting seems to follow standard/default Prettier conventions, so I've added that here. The only formatting changes are a few related to print width and missing trailing commas. I've ignored the autogenerated CHANGELOG.md and the pnpm lockfile in `.prettierignore`.