### PR TITLE
feat: add cm-button and cm-textfield

### DIFF
--- a/src/catppuccin.ts
+++ b/src/catppuccin.ts
@@ -64,7 +64,7 @@ function createCatppuccinTheme(flavor: CatppuccinFlavor) {
       },
 
       ".cm-button": {
-        backgroundColor: colors.surface0.hex,
+        backgroundImage: `linear-gradient(${colors.surface1.hex}, ${colors.surface0.hex})`,
         border: `1px solid ${colors.overlay0.hex}`,
       },
 

--- a/src/catppuccin.ts
+++ b/src/catppuccin.ts
@@ -68,6 +68,10 @@ function createCatppuccinTheme(flavor: CatppuccinFlavor) {
         border: `1px solid ${colors.overlay0.hex}`,
       },
 
+      ".cm-button:active": {
+        backgroundImage: `linear-gradient(${colors.surface0.hex}, ${colors.surface1.hex})`,
+      },
+
       ".cm-activeLineGutter": {
         backgroundColor: colors.surface0.hex,
       },

--- a/src/catppuccin.ts
+++ b/src/catppuccin.ts
@@ -25,7 +25,7 @@ function createCatppuccinTheme(flavor: CatppuccinFlavor) {
 
       "&.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection":
         {
-          backgroundColor: `${colors.overlay2.hex}40`
+          backgroundColor: `${colors.overlay2.hex}40`,
         },
 
       ".cm-panels": {
@@ -57,6 +57,15 @@ function createCatppuccinTheme(flavor: CatppuccinFlavor) {
         backgroundColor: colors.base.hex,
         color: colors.subtext0.hex,
         border: "none",
+      },
+
+      ".cm-textfield": {
+        border: `1px solid ${colors.overlay0.hex}`,
+      },
+
+      ".cm-button": {
+        backgroundColor: colors.surface0.hex,
+        border: `1px solid ${colors.overlay0.hex}`,
       },
 
       ".cm-activeLineGutter": {


### PR DESCRIPTION
Used in a few user-oriented prompts and panels, including the find and replace panel!

<img width="743" height="80" alt="image" src="https://github.com/user-attachments/assets/0db4e32e-c37f-41b9-98ff-b561e76d1419" />

Here's an example: text field, pressed button, then regular buttons.