### PR TITLE
fix(catppuccin.ts): make active line background translucent

### DIFF
--- a/src/catppuccin.ts
+++ b/src/catppuccin.ts
@@ -47,7 +47,10 @@ function createCatppuccinTheme(flavor: CatppuccinFlavor) {
         backgroundColor: `${colors.blue.hex}2f`,
       },
 
-      ".cm-activeLine": { backgroundColor: colors.surface0.hex },
+      // drawSelection() paints the selection on a layer behind the text, so
+      // the active-line background must be translucent to keep the selection
+      // visible on that line.
+      ".cm-activeLine": { backgroundColor: `${colors.surface0.hex}66` },
       ".cm-selectionMatch": {
         backgroundColor: `${colors.surface2.hex}4d`,
       },


### PR DESCRIPTION
drawSelection() draws the selection on a layer behind the editor text (z-index -2 by design), so any opaque background at content level hides it. The opaque surface0 fill on .cm-activeLine made a selection inside the active line invisible. Add alpha to the fill so the selection shows through, the same approach the CodeMirror base theme uses for .cm-activeLine.

Fixes issue #19